### PR TITLE
upgrade to microsoft/azure-storage-blob

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "league/flysystem": "~1.0",
-        "microsoft/azure-storage": "^0.19.1"
+        "microsoft/azure-storage-blob": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
https://packagist.org/packages/microsoft/azure-storage
> This package is abandoned and no longer maintained. The author suggests using the `microsoft/azure-storage-blob`, `microsoft/azure-storage-table`, `microsoft/azure-storage-queue`, `microsoft/azure-storage-file` package instead.